### PR TITLE
add a type signature for the TH `initWorld` splice

### DIFF
--- a/src/Apecs/TH.hs
+++ b/src/Apecs/TH.hs
@@ -31,13 +31,16 @@ makeWorldNoEC worldName cTypes = do
             [] ]
           ]
 
-      initDecl = FunD (mkName $ "init" ++ worldName) [Clause []
+      initWorldName = mkName $ "init" ++ worldName
+      initSig = SigD initWorldName (AppT (ConT (mkName "IO")) (ConT wld))
+      initDecl = FunD initWorldName [Clause []
         (NormalB$ iterate (\wE -> AppE (AppE (VarE $ mkName "<*>") wE) (VarE $ mkName "initStore")) (AppE (VarE $ mkName "return") (ConE wld)) !! length records)
         [] ]
 
       hasDecl = makeInstance <$> cTypesNames
 
-  return $ wldDecl : initDecl : hasDecl
+  
+  return $ wldDecl : initSig : initDecl : hasDecl
 
 {-|
 


### PR DESCRIPTION
This was causing my code which uses the `makeWorld` utility to throw warnings because of -Wmissing-signatures. With this change, the splice now generates the appropriate type signature as well.