### PR TITLE
make Global always return true for `explExists`

### DIFF
--- a/src/Apecs/Stores.hs
+++ b/src/Apecs/Stores.hs
@@ -198,7 +198,7 @@ instance Monoid c => Store (Global c) where
 
   type SafeRW (Global c) = c
   explDestroy _ _ = return ()
-  explExists _ _ = return False
+  explExists _ _ = return True
   explGetUnsafe (Global ref) _ = readIORef ref
   explGet (Global ref) _ = readIORef ref
   explSet (Global ref) _ c = writeIORef ref c

--- a/src/Apecs/Stores.hs
+++ b/src/Apecs/Stores.hs
@@ -198,7 +198,7 @@ instance Monoid c => Store (Global c) where
 
   type SafeRW (Global c) = c
   explDestroy _ _ = return ()
-  explExists _ _ = return True
+  explExists _ _ = return False
   explGetUnsafe (Global ref) _ = readIORef ref
   explGet (Global ref) _ = readIORef ref
   explSet (Global ref) _ c = writeIORef ref c

--- a/src/Apecs/System.hs
+++ b/src/Apecs/System.hs
@@ -188,6 +188,5 @@ writeGlobal c = do s :: Storage c <- getStore
 -- | Modifies a global value
 {-# INLINE modifyGlobal #-}
 modifyGlobal :: forall w c. (Has w c, GlobalStore (Storage c)) => (c -> c) -> System w ()
-modifyGlobal f = do s :: Storage c <- getStore
-                    liftIO$ explModify s 0 f
+modifyGlobal f = readGlobal >>= writeGlobal . f
 

--- a/src/Apecs/Types.hs
+++ b/src/Apecs/Types.hs
@@ -50,6 +50,10 @@ class Store s where
   explDestroy :: s -> Int -> IO ()
   -- | Returns whether there is a component for the given index
   explExists  :: s -> Int -> IO Bool
+  explExists s n = do
+    mems <- explMembers s
+    return $ U.elem n mems
+
   -- | Returns an unboxed vector of member indices
   explMembers :: s -> IO (U.Vector Int)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -119,6 +119,19 @@ loggerProp s = assertSys initLoggerProp $ do
   return (sl == U.fromList (S.toList set))
 
 
+newtype G = G Bool deriving (Eq, Show)
+instance Monoid G where
+  mempty = G False
+  mappend (G x) (G y) = G (x || y)
+instance Component G where
+  type Storage G = Global G
+
+makeWorld "GProp" [''G]
+
+gProp = assertSys initGProp $ do
+  modifyGlobal $ \(G x) -> G (not x)
+  G x <- readGlobal
+  return $ x == True
 
 main = do
   quickCheck setGetProp
@@ -126,3 +139,4 @@ main = do
   quickCheck setGetPropC
   quickCheck loggerProp
   quickCheck listMembersIsSlice
+  quickCheck gProp


### PR DESCRIPTION
this was causing `modifyGlobal` to always be a noop since `explModify` only modifies the entity if it exists

i'm not sure if `Const`'s `explExists` should always return true as well, but that's probably worth taking a look at