### PR TITLE
Fix readme example so it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ It provides a collection of mutable component stores, and an expressive DSL for 
 
 #### Example
 ```haskell
-{-# LANGUAGE DataKinds, TypeFamilies, MultiParamTypeClasses #-}
+{-# LANGUAGE DataKinds, TypeFamilies, MultiParamTypeClasses, TemplateHaskell #-}
 
 import Apecs
+import Apecs.Stores
 import Linear (V2)
 
 newtype Position = Position (V2 Double) deriving Show


### PR DESCRIPTION
The example in the readme file doesn't compile - it's missing the `TemplateHaskell` extension (for `makeWorld`) and an import of `Apecs.Stores` (for `Cache`). This pull request fixes these problems.