### PR TITLE
Allow compiling with latest GHC

### DIFF
--- a/src/Apecs/Util.hs
+++ b/src/Apecs/Util.hs
@@ -39,7 +39,7 @@ global = Entity (-1)
 
 -- | Component used by newEntity to track the number of issued entities.
 --   Automatically added to any world created with @makeWorld@
-newtype EntityCounter = EntityCounter {getCounter :: Sum Int} deriving (Monoid, Eq, Show)
+newtype EntityCounter = EntityCounter {getCounter :: Sum Int} deriving (Semigroup, Monoid, Eq, Show)
 
 instance Component EntityCounter where
   type Storage EntityCounter = Global EntityCounter


### PR DESCRIPTION
A deriving Semigroup has been added as latest base requires Monoids to be Semigroups.