### PR TITLE
Add 'CollisionHandler' and related helper methods

### DIFF
--- a/apecs-physics/src/Apecs/Physics.hs
+++ b/apecs-physics/src/Apecs/Physics.hs
@@ -25,6 +25,8 @@ module Apecs.Physics (
   -- * Collision
   Collision (..), CollisionHandler (..), defaultHandler,
   CollisionSource(..), BeginCB, SeparateCB, PreSolveCB, PostSolveCB,
+  mapMCollideHandler, mapCollideHandler, collideHandlerOr,
+  collideHandlerAnd, postSolveCollideHandler, 
   mkBeginCB, mkSeparateCB, mkPreSolveCB, mkPostSolveCB,
 
   -- * Query


### PR DESCRIPTION
This commit provides a few abstractions to make using collision detection a bit nicer. The names, unfortunately, probably need work.

More specifically, this provides:

- `CollideHandler`, an abstract type representing "computations that can handle what to do after a collision, which may fail"
- `mapMCollideHandler`, which is basically `mapM` but after a collision happens (failing if the entities in the collision couldn't be mapped over)
- `mapCollideHandler`, which is the above but non-effectful
- `collideHandlerOr`, which tries to run one `CollideHandler`, then runs another if the first fails
- `collideHandlerAnd`, which runs two `CollideHandler`s in a sequence, and succeeds if either succeed.

I'm not sure if the API on this is as easy to understand as it should be, so this should be thought of as more of a "starting step" rather than anything else.