### PR TITLE
Fix monoid examples

### DIFF
--- a/examples/Shmup.lhs
+++ b/examples/Shmup.lhs
@@ -12,14 +12,15 @@ Let's start at the top.
 Apecs' type-level machinery tends to effect a large number of pragma's.
 Don't worry, GHC will happily let you know if you missed any.
 
-> {-# LANGUAGE DataKinds             #-}
-> {-# LANGUAGE FlexibleContexts      #-}
-> {-# LANGUAGE FlexibleInstances     #-}
-> {-# LANGUAGE MultiParamTypeClasses #-}
-> {-# LANGUAGE ScopedTypeVariables   #-}
-> {-# LANGUAGE TemplateHaskell       #-}
-> {-# LANGUAGE TypeApplications      #-}
-> {-# LANGUAGE TypeFamilies          #-}
+> {-# LANGUAGE DataKinds                  #-}
+> {-# LANGUAGE FlexibleContexts           #-}
+> {-# LANGUAGE FlexibleInstances          #-}
+> {-# LANGUAGE MultiParamTypeClasses      #-}
+> {-# LANGUAGE ScopedTypeVariables        #-}
+> {-# LANGUAGE TemplateHaskell            #-}
+> {-# LANGUAGE TypeApplications           #-}
+> {-# LANGUAGE TypeFamilies               #-}
+> {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 The `Apecs` module forms the apecs prelude, it re-exports everything you typically need.
 
@@ -92,10 +93,10 @@ The initial value of a `Global` will be drawn from that Component's `Monoid` ins
 
 `Score` keeps the score, and `Time` the total elapsed time.
 
-> newtype Score = Score Int deriving Show
+> newtype Score = Score Int deriving (Show, Num)
 > instance Semigroup Score where
->     (Score a) <> (Score b) = Score $ a + b 
-> instance Monoid Score where mempty = Score 0
+>     (<>) = (+)
+> instance Monoid Score where mempty = 0
 > instance Component Score where type Storage Score = Global Score
 > 
 > newtype Time = Time Float deriving Show

--- a/examples/Shmup.lhs
+++ b/examples/Shmup.lhs
@@ -93,12 +93,14 @@ The initial value of a `Global` will be drawn from that Component's `Monoid` ins
 `Score` keeps the score, and `Time` the total elapsed time.
 
 > newtype Score = Score Int deriving Show
-> instance Semigroup Score
+> instance Semigroup Score where
+>     (Score a) <> (Score b) = Score $ a + b 
 > instance Monoid Score where mempty = Score 0
 > instance Component Score where type Storage Score = Global Score
 > 
 > newtype Time = Time Float deriving Show
-> instance Semigroup Time
+> instance Semigroup Time where
+>     (Time t) <> (Time t') = Time $ t + t'
 > instance Monoid Time where mempty = Time 0
 > instance Component Time where type Storage Time = Global Time
 

--- a/examples/Shmup.md
+++ b/examples/Shmup.md
@@ -142,10 +142,10 @@ instance Monoid Score where mempty = 0
 
 instance Component Score where type Storage Score = Global Score
 
-newtype Time = Time Float deriving Show
+newtype Time = Time Float deriving (Show, Num)
 instance Semigroup Time where
-    (Time t) <> (Time t') = Time $ t + t'
-instance Monoid Time where mempty = Time 0
+    (<>) = (+)
+instance Monoid Time where mempty = 0
 instance Component Time where type Storage Time = Global Time
 ```
 

--- a/examples/Shmup.md
+++ b/examples/Shmup.md
@@ -18,14 +18,15 @@ large number of pragma’s. Don’t worry, GHC will happily let you know if
 you missed any.
 
 ``` haskell
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 ```
 
 The `Apecs` module forms the apecs prelude, it re-exports everything you
@@ -133,11 +134,11 @@ The initial value of a `Global` will be drawn from that Component’s
 `Score` keeps the score, and `Time` the total elapsed time.
 
 ``` haskell
-newtype Score = Score Int deriving Show
+newtype Score = Score Int deriving (Show, Num)
 instance Semigroup Score where
-    (Score a) <> (Score b) = Score $ a + b
+    (<>) = (+)
 
-instance Monoid Score where mempty = Score 0
+instance Monoid Score where mempty = 0
 
 instance Component Score where type Storage Score = Global Score
 

--- a/examples/Shmup.md
+++ b/examples/Shmup.md
@@ -134,12 +134,16 @@ The initial value of a `Global` will be drawn from that Component’s
 
 ``` haskell
 newtype Score = Score Int deriving Show
-instance Semigroup Score
+instance Semigroup Score where
+    (Score a) <> (Score b) = Score $ a + b
+
 instance Monoid Score where mempty = Score 0
+
 instance Component Score where type Storage Score = Global Score
 
 newtype Time = Time Float deriving Show
-instance Semigroup Time
+instance Semigroup Time where
+    (Time t) <> (Time t') = Time $ t + t'
 instance Monoid Time where mempty = Time 0
 instance Component Time where type Storage Time = Global Time
 ```


### PR DESCRIPTION
This basically fixes #26 by giving examples for how to make your `Global` values proper `Monoid`s.

I considered adding in a `gmappend` in this PR but figured that should probably be in its own. 