### PR TITLE
Make pqGradient vec instead of double

### DIFF
--- a/apecs-physics/src/Apecs/Physics/Types.hs
+++ b/apecs-physics/src/Apecs/Physics/Types.hs
@@ -294,8 +294,8 @@ data PointQueryResult = PointQueryResult
   -- ^ The closest point on the shape's surface (in world space)
   , pqDistance :: Double
   -- ^ The distance to the queried point
-  , pqGradient :: Double
+  , pqGradient :: Vec
   -- ^ The gradient of the distance function.
-  -- This is equal to 'pqPoint'/'pqDistance' but accurate for even
-  -- very small distances. 
+  -- This should be similar to 'pqPoint'/'pqDistance' but accurate even for
+  -- very small distances.
   } deriving (Eq, Show)


### PR DESCRIPTION
I think this is the root cause of #22 

I would also suggest using `alloca` instead of `malloc` and `free`, since it is faster and seems appropriate in this situation. I have no idea if that is measurable, though, so I haven't included it.