### PR TITLE
Add makeMapComponents

### DIFF
--- a/apecs/src/Apecs/TH.hs
+++ b/apecs/src/Apecs/TH.hs
@@ -3,6 +3,7 @@
 
 module Apecs.TH
   ( makeWorld, makeWorldNoEC, makeWorldAndComponents
+  , makeMapComponents
   ) where
 
 import Control.Monad
@@ -49,8 +50,11 @@ makeWorldNoEC worldName cTypes = do
 
   return $ wldDecl : initSig : initDecl : hasDecl
 
-makeComponent :: Name -> Q Dec
-makeComponent comp = do
+makeMapComponents :: [Name] -> Q [Dec]
+makeMapComponents = mapM makeMapComponent
+
+makeMapComponent :: Name -> Q Dec
+makeMapComponent comp = do
   let ct = return$ ConT comp
   head <$> [d| instance Component $ct where type Storage $ct = Map $ct |]
 
@@ -58,7 +62,7 @@ makeComponent comp = do
 makeWorldAndComponents :: String -> [Name] -> Q [Dec]
 makeWorldAndComponents worldName cTypes = do
   wdecls <- makeWorld worldName cTypes
-  cdecls <- mapM makeComponent cTypes
+  cdecls <- makeMapComponents cTypes
   return $ wdecls ++ cdecls
 
 {-|


### PR DESCRIPTION
The `makeWorldAndComponents` is nice and saves a lot of typing pain. However one silly `Unique` component breaks it entirely and forces to type all the missing Map storages.

There is `makeComponent` that could do that but it isn't exposed and needs a `mapM` wrapper anyway.

So this patch adds a thin wrapper over it to complement `makeWorld`.