### PR TITLE
Fix broken link to tutorial by other author

### DIFF
--- a/apecs/README.md
+++ b/apecs/README.md
@@ -20,7 +20,7 @@ apecs aims to be
 - [apecs-stm](../apecs-stm/) - STM-based stores for easy concurrency
 
 ##### By other authors
-- [An Introduction to Developing Games in Haskell with Apecs](https://steemit.com/blog/@aas-sh/an-introduction-to-developing-games-in-haskell-with-apecs) by Ashley Smith
+- [An Introduction to Developing Games in Haskell with Apecs](https://aas.sh/blog/making-a-game-with-haskell-and-apecs/) by Ashley Smith
 
 #### Status
 | Package | Hackage | Stack LTS | Stack Nightly |

--- a/apecs/README.md
+++ b/apecs/README.md
@@ -20,7 +20,7 @@ apecs aims to be
 - [apecs-stm](../apecs-stm/) - STM-based stores for easy concurrency
 
 ##### By other authors
-- [An Introduction to Developing Games in Haskell with Apecs](https://blog.aas.sh/posts/2018-09-10-Making-A-Game-With-Haskell-And-Apecs/) by Ashley Smith
+- [An Introduction to Developing Games in Haskell with Apecs](https://steemit.com/blog/@aas-sh/an-introduction-to-developing-games-in-haskell-with-apecs) by Ashley Smith
 
 #### Status
 | Package | Hackage | Stack LTS | Stack Nightly |


### PR DESCRIPTION
I have no idea what `steemit` is or why it's hosting this article, but the original link is broken and I found this with some googling and it seemed to be pretty likely that it was the same article.