### PR TITLE
Import stuff from base instead of mtl

### DIFF
--- a/apecs/src/Apecs.hs
+++ b/apecs/src/Apecs.hs
@@ -27,7 +27,8 @@ module Apecs (
     asks, ask, liftIO, lift, Proxy (..)
 ) where
 
-import           Control.Monad.Reader (ask, asks, lift, liftIO)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Reader (ask, asks, lift)
 import           Data.Proxy
 
 import           Apecs.Components

--- a/apecs/src/Apecs/Core.hs
+++ b/apecs/src/Apecs/Core.hs
@@ -12,6 +12,7 @@
 module Apecs.Core where
 
 import           Control.Monad.Catch
+import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import qualified Data.Vector.Unboxed  as U
 

--- a/apecs/src/Apecs/Experimental/Reactive.hs
+++ b/apecs/src/Apecs/Experimental/Reactive.hs
@@ -25,6 +25,8 @@ module Apecs.Experimental.Reactive
   , IxMap, ixLookup
   ) where
 
+import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import qualified Data.Array.IO        as A
 import qualified Data.IntMap.Strict   as IM

--- a/apecs/src/Apecs/Stores.hs
+++ b/apecs/src/Apecs/Stores.hs
@@ -17,6 +17,8 @@ module Apecs.Stores
     -- Register, regLookup
   ) where
 
+import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Data.Bits                   (shiftL, (.&.))
 import qualified Data.IntMap.Strict          as M

--- a/apecs/src/Apecs/System.hs
+++ b/apecs/src/Apecs/System.hs
@@ -6,6 +6,7 @@
 
 module Apecs.System where
 
+import           Control.Monad
 import           Control.Monad.Reader
 import           Data.Proxy
 import qualified Data.Vector.Unboxed  as U

--- a/apecs/src/Apecs/Util.hs
+++ b/apecs/src/Apecs/Util.hs
@@ -17,6 +17,7 @@ module Apecs.Util (
 ) where
 
 import           Control.Applicative  (liftA2)
+import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Data.Monoid
 import           Data.Semigroup


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `apecs` in line with the proposed change.