### PR TITLE
Update README.md

### DIFF
--- a/apecs/README.md
+++ b/apecs/README.md
@@ -85,3 +85,7 @@ game = do
 main :: IO ()
 main = initWorld >>= runSystem game
 ```
+
+### Dependencies
+
+To be successfuly built, the repo relies on you having (at least) the GLU dev package on your machine.  


### PR DESCRIPTION
Add dependency about glu-dev.

Without that package on my system, a `stack build` was failing without any kind of obvious error, and one had to go though pages of  `stack build --verbose` to find ... a **warning** about it.  