### PR TITLE
feat(apecs-stm): create `makeWorldAndComponents` for STM

### DIFF
--- a/apecs-stm/src/Apecs/STM.hs
+++ b/apecs-stm/src/Apecs/STM.hs
@@ -18,7 +18,7 @@ module Apecs.STM
   , Global (..)
     -- * EntityCounter
   , EntityCounter (..)
-  , nextEntity, newEntity, makeWorld
+  , nextEntity, newEntity, makeWorld, makeWorldAndComponents
     -- * STM conveniences
   , atomically, retry, check, forkSys, threadDelay, STM
   ) where
@@ -40,7 +40,7 @@ import qualified StmContainers.Map           as M
 import           Apecs                       (ask, get, global, lift, liftIO,
                                               runSystem, set)
 import           Apecs.Core
-import           Apecs.TH                    (makeWorldNoEC)
+import           Apecs.TH                    (makeWorldNoEC, makeMapComponentsFor)
 
 newtype Map c = Map (M.Map Int c)
 type instance Elem (Map c) = c
@@ -184,6 +184,13 @@ newEntity c = do ety <- nextEntity
 -- | Like @makeWorld@ from @Apecs@, but uses the STM @EntityCounter@
 makeWorld :: String -> [Name] -> Q [Dec]
 makeWorld worldName cTypes = makeWorldNoEC worldName (cTypes ++ [''EntityCounter])
+
+-- | Like @makeWorldAndComponents@ from @Apecs@, but uses the STM @EntityCounter@ and the STM @Map@
+makeWorldAndComponents :: String -> [Name] -> Q [Dec]
+makeWorldAndComponents worldName cTypes = do
+  wdecls <- makeWorld worldName cTypes
+  cdecls <- makeMapComponentsFor ''Map cTypes
+  pure $ wdecls ++ cdecls
 
 -- | @atomically@ from STM, lifted to the System level.
 atomically :: SystemT w STM a -> SystemT w IO a

--- a/apecs-stm/src/Apecs/STM/Prelude.hs
+++ b/apecs-stm/src/Apecs/STM/Prelude.hs
@@ -7,7 +7,7 @@ module Apecs.STM.Prelude
   ) where
 
 import           Apecs     hiding (EntityCounter, Global, Map, System, Unique,
-                            makeWorld, newEntity)
+                            makeWorld, makeWorldAndComponents, newEntity)
 import           Apecs.STM
 
 type System w a = SystemT w STM a

--- a/apecs/src/Apecs/TH.hs
+++ b/apecs/src/Apecs/TH.hs
@@ -6,6 +6,7 @@ module Apecs.TH
   , makeWorldNoEC
   , makeWorldAndComponents
   , makeMapComponents
+  , makeMapComponentsFor
   ) where
 
 import           Control.Monad
@@ -57,9 +58,17 @@ makeMapComponents :: [Name] -> Q [Dec]
 makeMapComponents = mapM makeMapComponent
 
 makeMapComponent :: Name -> Q Dec
-makeMapComponent comp = do
-  let ct = return$ ConT comp
-  head <$> [d| instance Component $ct where type Storage $ct = Map $ct |]
+makeMapComponent = makeMapComponentFor ''Map
+
+-- | Allows customization of the store to be used. For example, the base 'Map' or an STM Map.
+makeMapComponentFor :: Name -> Name -> Q Dec
+makeMapComponentFor store comp = do
+  let ct = pure $ ConT comp
+      st = pure $ ConT store
+  head <$> [d| instance Component $ct where type Storage $ct = $st $ct |]
+
+makeMapComponentsFor :: Name -> [Name] -> Q [Dec]
+makeMapComponentsFor store = mapM (makeMapComponentFor store)
 
 -- | Calls 'makeWorld' and 'makeMapComponents', i.e. makes a world and also defines 'Component' instances with a 'Map' store.
 makeWorldAndComponents :: String -> [Name] -> Q [Dec]


### PR DESCRIPTION
Currently, the `makeWorld` TH function from `Apecs.STM` does not
create (STM) Map components for the given input component types, and
`Apecs.TH.makeMapComponents` only creates non-STM components.

By creating an alternative `makeMapComponent` TH function that takes
the store type as an input, we can generate the instance declarations
for both classic and STM Map stores. Also, it eases the usage of the
module by its user.