### PR TITLE
add `newEntity_` to Apecs.Util

### DIFF
--- a/apecs/src/Apecs.hs
+++ b/apecs/src/Apecs.hs
@@ -20,7 +20,7 @@ module Apecs (
 
   -- * Other
     runSystem, runWith,
-    runGC, EntityCounter, newEntity, global,
+    runGC, EntityCounter, newEntity, newEntity_, global,
     makeWorld, makeWorldAndComponents,
 
   -- * Re-exports

--- a/apecs/src/Apecs/Util.hs
+++ b/apecs/src/Apecs/Util.hs
@@ -13,7 +13,7 @@ module Apecs.Util (
   runGC, global,
 
   -- * EntityCounter
-  EntityCounter(..), nextEntity, newEntity,
+  EntityCounter(..), nextEntity, newEntity, newEntity_,
 ) where
 
 import           Control.Applicative  (liftA2)
@@ -53,6 +53,15 @@ newEntity :: (MonadIO m, Set w m c, Get w m EntityCounter)
 newEntity c = do ety <- nextEntity
                  set ety c
                  return ety
+
+-- | Writes the given components to a new entity without yelding the result.
+-- Used mostly for convenience.
+{-# INLINE newEntity_ #-}
+newEntity_ :: (MonadIO m, Set world m component, Get world m EntityCounter)
+           => component -> SystemT world m ()
+newEntity_ component = do
+  entity <- nextEntity
+  set entity component
 
 -- | Explicitly invoke the garbage collector
 runGC :: System w ()


### PR DESCRIPTION
The sole purpose of adding this function is to avoid annoying build warnings with `-Wall` and most notably writing superfluous code like:
```haskell 
initGame = do
  _ <- newEntity (DungeonMaster, Bucks 300)
  -- | or
  void (newEntity (MyDad, LeftMe True))
  -- | instead of
  newEntity_ (Waifu, Name "Makise Kurisu", Position maxBound maxBound)
```