### PR TITLE
Fix build of apecs-physics with glibc >= 2.32

### DIFF
--- a/apecs-physics/Chipmunk2D/src/cpHastySpace.c
+++ b/apecs-physics/Chipmunk2D/src/cpHastySpace.c
@@ -7,8 +7,11 @@
 //TODO: Move all the thread stuff to another file
 
 //#include <sys/param.h >
-#ifndef _WIN32
+#ifdef __APPLE__
 #include <sys/sysctl.h>
+#endif
+
+#ifndef _WIN32
 #include <pthread.h>
 #else
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
sys/sysctl.h has been deprecated on Linux and now removed from glibc.
Since it is only used on macOS anyways, we only include it if __APPLE__
is defined.

> * The deprecated <sys/sysctl.h> header and the sysctl function have been
>  removed.  To support old binaries, the sysctl function continues to
>  exist as a compatibility symbol (on those architectures which had it),
>  but always fails with ENOSYS.  This reflects the removal of the system
>  call from all architectures, starting with Linux 5.5.

https://sourceware.org/pipermail/libc-announce/2020/000029.html