### PR TITLE
Bump mtl upper bound, CI GHC versions

### DIFF
--- a/apecs/apecs.cabal
+++ b/apecs/apecs.cabal
@@ -42,7 +42,7 @@ library
     , base              >=4.9    && <5
     , containers        >=0.5    && <0.8
     , exceptions        >=0.10.0 && <0.11
-    , mtl               >=2.2    && <2.3
+    , mtl               >=2.2    && <2.4
     , template-haskell  >=2.12   && <3
     , vector            >=0.11   && <0.14
 

--- a/flake.lock
+++ b/flake.lock
@@ -17,15 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678337105,
-        "narHash": "sha256-8mCjm/IgwIW70mcZBCLLdUvN0hN3wzVbyBpJUX9dTY4=",
+        "lastModified": 1686926720,
+        "narHash": "sha256-S49KAii1WiYGAYza+ZJR8Nem142YJ4Nkt4gMvZiovS0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a71e45961e88c8a6dde6287fa1e061f30f8c2fb7",
+        "rev": "b1bdd38ad9c3b67c25101b87906f6cc3b628317d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "apecs";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = inputs:


### PR DESCRIPTION
https://github.com/commercialhaskell/stackage/issues/6857

mtl 2.3 has been released, should be a straightforward bump of the upper bound. We don't need to cut a new release, we should be able to just make a revision.