### PR TITLE
Add ComponentCounter to Apecs.Experimental.Reactive

### DIFF
--- a/apecs/src/Apecs/Experimental/Reactive.hs
+++ b/apecs/src/Apecs/Experimental/Reactive.hs
@@ -20,6 +20,7 @@ Use e.g. @rget >>= mapLookup True@ to retrieve a list of entities that have a @T
 
 module Apecs.Experimental.Reactive
   ( Reacts (..), Reactive, withReactive
+  , Printer
   , EnumMap, enumLookup
   , OrdMap, ordLookup
   , IxMap, ixLookup

--- a/apecs/src/Apecs/Experimental/Reactive.hs
+++ b/apecs/src/Apecs/Experimental/Reactive.hs
@@ -8,7 +8,7 @@ Adds the @Reactive r s@ store, which when wrapped around store @s@, will call th
 @Show c => Reactive (Printer c) (Map c)@ will print a message every time a @c@ value is set.
 
 @Enum c => Reactive (EnumMap c) (Map c)@ allows you to look up entities by component value.
-Use e.g. @rget >>= mapLookup True@ to retrieve a list of entities that have a @True@ component.
+Use e.g. @withReactive $ enumLookup True@ to retrieve a list of entities that have a @True@ component.
 
 -}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -107,7 +107,7 @@ instance (MonadIO m, Show c) => Reacts m (Printer c) where
   react _ _ _ _ = return ()
 
 -- | Allows you to look up entities by component value.
---   Use e.g. @withReactive $ mapLookup True@ to retrieve a list of entities that have a @True@ component.
+--   Use e.g. @withReactive $ enumLookup True@ to retrieve a list of entities that have a @True@ component.
 --   Based on an @IntMap IntSet@ internally.
 newtype EnumMap c = EnumMap (IORef (IM.IntMap S.IntSet))
 


### PR DESCRIPTION
Adds a reactive `ComponentCounter` to track current and max counts of entities with the particular `Component` assigned.

The PR also includes some minor, unrelated updates to the `Apecs.Experimental.Reactive` (haddocks and exporting the `Printer` type).

I'm not sure if there's a protocol for what makes it into the experimental modules, so I defaulted to putting the PR up just to have some code to look at. Let me know if there's a preference on discussing in an issue first.