### PR TITLE
Add MonadUnliftIO instance for SystemT

### DIFF
--- a/apecs/apecs.cabal
+++ b/apecs/apecs.cabal
@@ -44,6 +44,7 @@ library
     , exceptions        >=0.10.0 && <0.11
     , mtl               >=2.2    && <2.4
     , template-haskell  >=2.12   && <3
+    , unliftio-core     >=0.2.0.1 && <0.3
     , vector            >=0.11   && <0.14
 
   ghc-options:      -Wall

--- a/apecs/src/Apecs/Core.hs
+++ b/apecs/src/Apecs/Core.hs
@@ -13,6 +13,7 @@ module Apecs.Core where
 
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
+import           Control.Monad.IO.Unlift
 import           Control.Monad.Reader
 import qualified Data.Vector.Unboxed  as U
 
@@ -28,7 +29,7 @@ newtype Entity = Entity {unEntity :: Int} deriving (Num, Eq, Ord, Show, Enum)
 --   * Allow type-based lookup of a component's store through @getStore@.
 --
 --   * Lift side effects into their host Monad.
-newtype SystemT w m a = SystemT {unSystem :: ReaderT w m a} deriving (Functor, Monad, Applicative, MonadTrans, MonadIO, MonadThrow, MonadCatch, MonadMask)
+newtype SystemT w m a = SystemT {unSystem :: ReaderT w m a} deriving (Functor, Monad, Applicative, MonadTrans, MonadIO, MonadThrow, MonadCatch, MonadMask, MonadUnliftIO)
 type System w a = SystemT w IO a
 
 deriving instance Monad m => MonadReader w (SystemT w m)


### PR DESCRIPTION
Adds a newtype-derived `MonadUnliftIO` instance for `SystemT` so that systems can more conveniently use functions that are in callback style, e.g. [`alloca`](https://hackage.haskell.org/package/base-4.19.0.0/docs/Foreign-Marshal-Alloc.html#v:alloca).