### PR TITLE
Force IntMap in ExplDestroy instance for Map

### DIFF
--- a/apecs/src/Apecs/Stores.hs
+++ b/apecs/src/Apecs/Stores.hs
@@ -60,7 +60,7 @@ instance MonadIO m => ExplSet m (Map c) where
 instance MonadIO m => ExplDestroy m (Map c) where
   {-# INLINE explDestroy #-}
   explDestroy (Map ref) ety = liftIO$
-    readIORef ref >>= writeIORef ref . M.delete ety
+    modifyIORef' ref (M.delete ety)
 
 instance MonadIO m => ExplMembers m (Map c) where
   {-# INLINE explMembers #-}


### PR DESCRIPTION
The `instance MonadIO m => ExplDestroy m (Map c)` instance wasn't forcing the underlying `IntMap`, which leads to thunk buildup if new entities are created and then destroyed without any gets/sets in between.

<details>
  <summary><b>Sample program demonstrating leak</b></summary>

Program was run with `+RTS -s -hT -l -i0.01` profiling flags, then the resulting eventlog was fed to `eventlog2html`.

```haskell
import Apecs
import Control.Concurrent (threadDelay)
import Control.Monad (replicateM_)
import Data.Kind (Type)
import Debug.Trace (traceMarkerIO)
import Linear (V2(V2))
import Prelude

type Pos :: Type
newtype Pos = Pos (V2 Double)
  deriving stock (Show)

instance Component Pos where
  type Storage Pos = (Map Pos)

makeWorld "World" [''Pos]
type World :: Type

main :: IO ()
main = do
  world <- initWorld
  runWith world do
    createEntities
    destroyEntities
    sleep

createEntities :: System World ()
createEntities = do
  liftIO $ traceMarkerIO "Creating entities"
  replicateM_ entityCount $ newEntity_ $ Pos $ V2 0 0

destroyEntities :: System World ()
destroyEntities = do
  liftIO $ traceMarkerIO "Destroying entities"
  go 0
  where
  go curEnt
    | curEnt >= entityCount = pure ()
    | otherwise = do
        destroy (Entity curEnt) $ Proxy @Pos
        go $ 1 + curEnt

entityCount :: Int
entityCount = 10_000_000

sleep :: System World ()
sleep =
 liftIO do
   traceMarkerIO "Sleep"
   threadDelay 1_000_000
```
</details>

<details>
  <summary><b>Profile before change</b></summary>
  
The `IntMap` grows and grows as expected up until we start destroying entities. At that point, we have thunk buildup from the unforced `IntMap.delete` calls:
  
![linechart-01](https://github.com/jonascarpay/apecs/assets/1744045/918cc4ea-0c25-4609-ad33-724723aa8f4c)
![linechart-02](https://github.com/jonascarpay/apecs/assets/1744045/d22ff751-f156-4fc5-bc81-cd2424de4840)
</details>

<details>
  <summary><b>Profile after change</b></summary>
  
![linechart-after](https://github.com/jonascarpay/apecs/assets/1744045/73b181a3-4fe0-4028-ab9d-00e595b57f25)
</details>