### PR TITLE
Export cmapIf from main Apecs module

### DIFF
--- a/apecs/src/Apecs.hs
+++ b/apecs/src/Apecs.hs
@@ -15,7 +15,7 @@ module Apecs (
     get, set, ($=),
     destroy, exists,
     modify, ($~),
-    cmap,  cmapM,  cmapM_,
+    cmap, cmapIf, cmapM, cmapM_,
     cfold, cfoldM, cfoldM_, collect,
 
   -- * Other


### PR DESCRIPTION
The other `cmap`/`cfold` variants, `collect`, etc. are exported from the main `Apecs` module, so `cmapIf` likely should be as well so that users don't have to pull it from `Apecs.System`.