### PR TITLE
Use SystemT instead of System in runGC type signature

### DIFF
--- a/apecs/src/Apecs/Util.hs
+++ b/apecs/src/Apecs/Util.hs
@@ -64,5 +64,5 @@ newEntity_ component = do
   set entity component
 
 -- | Explicitly invoke the garbage collector
-runGC :: System w ()
-runGC = lift performMajorGC
+runGC :: MonadIO m => SystemT w m ()
+runGC = liftIO performMajorGC


### PR DESCRIPTION
`runGC`'s type signature was previously constrained to `System w ()`.