### PR TITLE
Add -XTypeOperators to get rid of warnings

### DIFF
--- a/apecs/src/Apecs/Core.hs
+++ b/apecs/src/Apecs/Core.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 
 module Apecs.Core where
 

--- a/apecs/src/Apecs/Experimental/Reactive.hs
+++ b/apecs/src/Apecs/Experimental/Reactive.hs
@@ -22,6 +22,7 @@ count can be useful for debugging entity lifecycles. To retrieve the counts, use
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 module Apecs.Experimental.Reactive
   ( Reacts (..), Reactive, withReactive

--- a/apecs/src/Apecs/Experimental/Stores.hs
+++ b/apecs/src/Apecs/Experimental/Stores.hs
@@ -13,6 +13,7 @@ This module is experimental, and its API might change between point releases. Us
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
 module Apecs.Experimental.Stores

--- a/apecs/src/Apecs/Stores.hs
+++ b/apecs/src/Apecs/Stores.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE Strict                #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 module Apecs.Stores
   ( Map, Cache, Unique,


### PR DESCRIPTION
Gets rid of the warnings about using `~` without having enabled `-XTypeOperators`:

```
The use of ‘~’ without TypeOperators
will become an error in a future GHC release.
Suggested fix: Perhaps you intended to use TypeOperators
```