### PR TITLE
Revert apecs-stm changes around EntityCounter

### DIFF
--- a/apecs-stm/CHANGELOG.md
+++ b/apecs-stm/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3]
+
+Reverting the 0.2 changes around `EntityCounter` and taking the codebase back to the 0.1.5 state.
+
+### Added
+- `newEntity_`, an STM counterpart of IO `newEntity_`.
+
 ## [0.2]
 ### Removed
 - Removed custom `EntityCounter`, `newEntity`, and `makeWorld`.

--- a/apecs-stm/apecs-stm.cabal
+++ b/apecs-stm/apecs-stm.cabal
@@ -1,5 +1,5 @@
 name:               apecs-stm
-version:            0.2
+version:            0.3
 homepage:           https://github.com/jonascarpay/apecs
 license:            BSD3
 license-file:       LICENSE

--- a/apecs-stm/src/Apecs/STM.hs
+++ b/apecs-stm/src/Apecs/STM.hs
@@ -18,7 +18,7 @@ module Apecs.STM
   , Global (..)
     -- * EntityCounter
   , EntityCounter (..)
-  , nextEntity, newEntity, makeWorld, makeWorldAndComponents
+  , nextEntity, newEntity, newEntity_, makeWorld, makeWorldAndComponents
     -- * STM conveniences
   , atomically, retry, check, forkSys, threadDelay, STM
   ) where
@@ -180,6 +180,12 @@ newEntity :: (Set w m c, Get w m EntityCounter, Set w m EntityCounter)
 newEntity c = do ety <- nextEntity
                  set ety c
                  return ety
+
+{-# INLINE newEntity_ #-}
+newEntity_ :: (Set w m c, Get w m EntityCounter, Set w m EntityCounter)
+          => c -> SystemT w m ()
+newEntity_ c = do ety <- nextEntity
+                  set ety c
 
 -- | Like @makeWorld@ from @Apecs@, but uses the STM @EntityCounter@
 makeWorld :: String -> [Name] -> Q [Dec]

--- a/apecs-stm/src/Apecs/STM/Prelude.hs
+++ b/apecs-stm/src/Apecs/STM/Prelude.hs
@@ -7,7 +7,7 @@ module Apecs.STM.Prelude
   ) where
 
 import           Apecs     hiding (EntityCounter, Global, Map, System, Unique,
-                            makeWorld, makeWorldAndComponents, newEntity)
+                            makeWorld, makeWorldAndComponents, newEntity, newEntity_)
 import           Apecs.STM
 
 type System w a = SystemT w STM a

--- a/apecs-stm/src/Apecs/STM/Prelude.hs
+++ b/apecs-stm/src/Apecs/STM/Prelude.hs
@@ -6,8 +6,8 @@ module Apecs.STM.Prelude
   , module Apecs
   ) where
 
-import           Apecs     hiding (Global, Map, System, Unique,
-                            makeWorldAndComponents)
+import           Apecs     hiding (EntityCounter, Global, Map, System, Unique,
+                            makeWorld, makeWorldAndComponents, newEntity)
 import           Apecs.STM
 
 type System w a = SystemT w STM a


### PR DESCRIPTION
Previously: #118, #119, #120

Unfortunately, switching from `IORef`/`writeIORef` to `TVar`/`atomically $ writeTVar` incurs 2.5x performance penalty.

I will post apecs-stm-0.3 and mark 0.2 deprecated..